### PR TITLE
feature/scrape-trading-pairs-from-announcements

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -11,6 +11,7 @@
     ENABLE_TSL: True
     TSL: -4
     TTP: 2
+    ENABLE_SMS: False
   LOGGING:
     # Logging levels used in this program are ERROR, INFO, and DEBUG
     LOG_LEVEL: INFO

--- a/main.py
+++ b/main.py
@@ -61,9 +61,12 @@ def main():
     pairing = config['TRADE_OPTIONS']['PAIRING']
     qty = config['TRADE_OPTIONS']['QUANTITY']
     test_mode = config['TRADE_OPTIONS']['TEST']
+    enable_sms = config['TRADE_OPTIONS']['ENABLE_SMS']
 
     if not test_mode:
         logger.info(f'!!! LIVE MODE !!!')
+        if(enable_sms):
+            logger.info('!!! SMS Enabled on Buy/Sell !!!')
 
     t = threading.Thread(target=search_and_update, args=[pairing,])
     t.start()
@@ -140,7 +143,7 @@ def main():
                         sold_message = f'sold {coin} with {(float(last_price) - stored_price) / float(stored_price)*100}% PNL'
                         logger.info(sold_message)
 
-                        if not test_mode:
+                        if not test_mode and enable_sms:
                             send_sms_message(sold_message)
 
                         # remove order from json file
@@ -253,7 +256,7 @@ def main():
                         message = f'Order created with {qty} on {announcement_coin} at a price of {price} each'
                         logger.info(message)
                         
-                        if not test_mode:
+                        if not test_mode and enable_sms:
                             send_sms_message(message)
 
                         store_order('order.json', order)

--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ def main():
     if not test_mode:
         logger.info(f'!!! LIVE MODE !!!')
 
-    t = threading.Thread(target=search_and_update)
+    t = threading.Thread(target=search_and_update, args=[pairing,])
     t.start()
 
     t2 = threading.Thread(target=get_all_currencies)

--- a/main.py
+++ b/main.py
@@ -189,6 +189,14 @@ def main():
         # announcement_coin = load_order('new_listing.json')
         if os.path.isfile('new_listing.json'):
             announcement_coin = load_order('new_listing.json')
+            if(len(announcement_coin) != 1):
+                if(len(order) > 0):
+                    announcement_coin = [c for c in announcement_coin if c not in order]
+                
+                if(len(announcement_coin) > 0):
+                    announcement_coin = announcement_coin[0]
+                else:
+                    announcement_coin = False
         else:
             announcement_coin = False
 

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from json import JSONEncoder
 import os.path
 import sys, os
 
-old_coins = ["CHESS", "OTHERCRAP"]
+old_coins = ["ADX", "AUCTION", "CHESS", "OTHERCRAP"]
 
 # loads local configuration
 config = load_config('config.yml')
@@ -100,8 +100,8 @@ def main():
 
                 stop_loss_price = stored_price + (stored_price*coin_sl /100)
 
-                logger.info(f'{last_price=}\t[BUY: ${"{:,.2f}".format(stored_price)} (+/-): {"{:,.2f}".format(((float(last_price) - stored_price) / stored_price) * 100)}%]\t[TOP: ${"{:,.2f}".format(top_position_price)} or {"{:,.2f}".format(coin_tp)}%]')
-                logger.info(f'{stop_loss_price=}  \t{"{:,.2f}".format(coin_sl)}%')
+                logger.info(f'{symbol=}-{last_price=}\t[BUY: ${"{:,.2f}".format(stored_price)} (+/-): {"{:,.2f}".format(((float(last_price) - stored_price) / stored_price) * 100)}%]\t[TOP: ${"{:,.2f}".format(top_position_price)} or {"{:,.2f}".format(coin_tp)}%]')
+                logger.info(f'{symbol=}-{stop_loss_price=}  \t{"{:,.2f}".format(coin_sl)}%')
 
                 # update stop loss and take profit values if threshold is reached
                 if float(last_price) > stored_price + (

--- a/new_listings_scraper.py
+++ b/new_listings_scraper.py
@@ -53,10 +53,9 @@ def store_new_listing(listing):
 
     if os.path.isfile('new_listing.json'):
         file = load_order('new_listing.json')
-        if listing in file:
+        if set(listing) == set(file):
             return file
         else:
-            file = listing
             store_order('new_listing.json', file)
             logger.info("New listing detected, updating file")
             return file

--- a/new_listings_scraper.py
+++ b/new_listings_scraper.py
@@ -2,7 +2,6 @@ import ast
 import os.path
 import re
 import time
-import re
 
 import requests
 from gate_api import ApiClient, SpotApi
@@ -61,7 +60,7 @@ def store_new_listing(listing):
         return new_listing
 
 
-def search_and_update():
+def search_and_update(pairing):
     """
     Pretty much our main func
     """

--- a/new_listings_scraper.py
+++ b/new_listings_scraper.py
@@ -15,28 +15,35 @@ spot_api = SpotApi(ApiClient(client))
 
 global supported_currencies
 
-def get_last_coin():
+def get_coins(pairing, page_num):
     """
-    Scrapes new listings page for and returns new Symbol when appropriate
+    Scrapes new listings page for and returns new Symbols when appropriate
     """
-    logger.debug("Pulling announcement page")
-    latest_announcement = requests.get("https://www.binance.com/bapi/composite/v1/public/cms/article/catalog/list/query?catalogId=48&pageNo=1&pageSize=15&rnd=" + str(time.time()))
+    latest_announcement = requests.get(f"https://www.binance.com/bapi/composite/v1/public/cms/article/catalog/list/query?catalogId=48&pageNo={page_num}&pageSize=1&rnd={str(time.time())}")
     latest_announcement = latest_announcement.json()
-    logger.debug("Finished pulling announcement page")
     latest_announcement = latest_announcement['data']['articles'][0]['title']
-    found_coin = re.findall('\(([^)]+)', latest_announcement)
-    uppers = None
+
+    if "adds" in latest_announcement.lower() and "trading pairs" in latest_announcement.lower() and pairing in latest_announcement:
+        found_pairs = re.findall(r'[A-Z]{1,10}[/][A-Z]*', latest_announcement)
+        found_coins = [i.replace(f'/{pairing}', "") for i in found_pairs if i.find(pairing) != -1]
+        return found_coins
+    elif "will list" in latest_announcement.lower():
+        found_coins = re.findall('\(([^)]+)', latest_announcement)
+        if(len(found_coins) > 0):
+            return found_coins
     
-    if 'Will List' not in latest_announcement:
-        return None
-    else:
-        if len(found_coin) == 1:
-            uppers = found_coin[0]
-            logger.info('New coin detected: ' + uppers)
-        if len(found_coin) != 1:
-            uppers = None
-    print(f'{uppers=}')
-    return uppers
+    return None
+
+
+def get_last_coin(pairing):
+    logger.debug("Pulling announcement page for [adds + trading pairs] or [will list] scenarios")
+
+    found_coins = get_coins(pairing, 1)
+    
+    if len(found_coins) > 0:
+        return found_coins
+    
+    return None
 
 
 def store_new_listing(listing):
@@ -70,9 +77,9 @@ def search_and_update(pairing):
     while True:
         time.sleep(3)
         try:
-            latest_coin = get_last_coin()
-            if latest_coin:
-                store_new_listing(latest_coin)
+            latest_coins = get_last_coin(pairing)
+            if len(latest_coins) > 0:
+                store_new_listing(latest_coins)
             
             count = count + 3
             if count % 60 == 0:


### PR DESCRIPTION
# feature/scrape-trading-pairs-from-announcements

## Overview
The scraping of announcements was only considering (1) titles that contain "Will List" and (2) one symbol per announcement.  The scraping should consider:
+ "Will List" (already supported)
+ "Add" + "Traiding Pair" + the pairing of the coin provided from config
+ Support multiple coins at one annoucement

For instance, the last announcement failed to trigger the automatic buyin for `"Binance Adds ADX/USDT, AUCTION/USDT, CELO/BUSD, FTM/RUB, NU/AUD, NU/RUB, REEF/BIDR & REEF/TRY Trading Pairs"`

For the last one hundred announcements, eight announcements contained "USDT" traiding pairs with multiple symbols
```
['ADX', 'AUCTION'] 
['DF', 'SYS']
['IDEX', 'POLY', 'VIDT']
['FOR', 'GHST', 'REQ']
['ALPACA', 'FARM']
['MINA', 'RAY']
['CLV', 'QNT']
['BOND', 'MLN']
```

## Checklist
+ [x] Add support for searching for trading pairs that match the config setup for the user specified traiding pair
+ [x] Add support for multiple symbols to be found in one annoucement title
+ [x] Updated `new_listing.json` file to contain an array of listings and updated the main thread to support multiple new listings
+ [x] Added opt-in config setting for sms messages. This allows bypassing sms messages easily.
