### PR TITLE
Feature/scrape trading pairs from announcements

### DIFF
--- a/main.py
+++ b/main.py
@@ -192,14 +192,19 @@ def main():
         # announcement_coin = load_order('new_listing.json')
         if os.path.isfile('new_listing.json'):
             announcement_coin = load_order('new_listing.json')
-            if(len(announcement_coin) != 1):
+            if(len(announcement_coin) > 0):
                 if(len(order) > 0):
                     announcement_coin = [c for c in announcement_coin if c not in order]
+                
+                if(len(announcement_coin) > 0):
+                    announcement_coin = [c for c in announcement_coin if c not in old_coins and c not in sold_coins]
                 
                 if(len(announcement_coin) > 0):
                     announcement_coin = announcement_coin[0]
                 else:
                     announcement_coin = False
+            else:
+                announcement_coin = False
         else:
             announcement_coin = False
 

--- a/new_listings_scraper.py
+++ b/new_listings_scraper.py
@@ -23,7 +23,7 @@ def get_coins(pairing, page_num):
     latest_announcement = latest_announcement.json()
     latest_announcement = latest_announcement['data']['articles'][0]['title']
 
-    if "adds" in latest_announcement.lower() and "trading pairs" in latest_announcement.lower() and pairing in latest_announcement:
+    if "adds" in latest_announcement.lower() and "trading pair" in latest_announcement.lower() and pairing in latest_announcement:
         found_pairs = re.findall(r'[A-Z]{1,10}[/][A-Z]*', latest_announcement)
         found_coins = [i.replace(f'/{pairing}', "") for i in found_pairs if i.find(pairing) != -1]
         return found_coins

--- a/new_listings_scraper.py
+++ b/new_listings_scraper.py
@@ -32,7 +32,7 @@ def get_coins(pairing, page_num):
         if(len(found_coins) > 0):
             return found_coins
     
-    return None
+    return False
 
 
 def get_last_coin(pairing):
@@ -40,10 +40,10 @@ def get_last_coin(pairing):
 
     found_coins = get_coins(pairing, 1)
     
-    if len(found_coins) > 0:
+    if found_coins and len(found_coins) > 0:
         return found_coins
     
-    return None
+    return False
 
 
 def store_new_listing(listing):
@@ -56,7 +56,8 @@ def store_new_listing(listing):
         if set(listing) == set(file):
             return file
         else:
-            store_order('new_listing.json', file)
+            joined = file + listing
+            store_order('new_listing.json', joined)
             logger.info("New listing detected, updating file")
             return file
     else:
@@ -77,7 +78,7 @@ def search_and_update(pairing):
         time.sleep(3)
         try:
             latest_coins = get_last_coin(pairing)
-            if len(latest_coins) > 0:
+            if latest_coins and len(latest_coins) > 0:
                 store_new_listing(latest_coins)
             
             count = count + 3


### PR DESCRIPTION
+ [x] Fix `NoneType` length error on new announcement
+ [x] Allow singular `trading pair` announcement to be considered.
+ [x] Ignore sold_coins when looking for a new annoucement to trigger order/buy in main thread