### PR TITLE
Feature/lowest ask

### DIFF
--- a/main.py
+++ b/main.py
@@ -143,17 +143,18 @@ def main():
                     obj = get_last_price(symbol, pairing, False)
                     if obj == False:
                         continue
+                    highest_bid = obj.highest_bid
                     last_price = obj.last
                     logger.debug("Finished get_last_price")
 
                     top_position_price = stored_price + (stored_price*coin_tp /100)
                     stop_loss_price = stored_price + (stored_price*coin_sl /100)
 
-                    # need positive price or continue and wait
+                    # need positive price or continue to next iteration
                     if float(last_price) == 0:
                         continue
 
-                    logger.info(f'{symbol=}-{last_price=}\t[STOP: ${"{:,.5f}".format(stop_loss_price)} or {"{:,.2f}".format(coin_sl)}%]\t[TOP: ${"{:,.5f}".format(top_position_price)} or {"{:,.2f}".format(coin_tp)}%]\t[BUY: ${"{:,.5f}".format(stored_price)} (+/-): {"{:,.2f}".format(((float(last_price) - stored_price) / stored_price) * 100)}%]')
+                    logger.info(f'{symbol=}-{last_price=}{highest_bid=}\t[STOP: ${"{:,.5f}".format(stop_loss_price)} or {"{:,.2f}".format(coin_sl)}%]\t[TOP: ${"{:,.5f}".format(top_position_price)} or {"{:,.2f}".format(coin_tp)}%]\t[BUY: ${"{:,.5f}".format(stored_price)} (+/-): {"{:,.2f}".format(((float(last_price) - stored_price) / stored_price) * 100)}%]')
 
                     # update stop loss and take profit values if threshold is reached
                     if float(last_price) > stored_price + (
@@ -189,11 +190,11 @@ def main():
                             pnl = (float(last_price) - stored_price)
                             pnl_perc = pnl / stored_price * 100
 
-                            logger.info(f'starting sell place_order with :{symbol} | {pairing} | {volume} | {sell_volume_adjusted} | {fees} | {float(sell_volume_adjusted)*float(last_price)} | side=sell | last={last_price}')
+                            logger.info(f'starting sell place_order with :{symbol} | {pairing} | {volume} | {sell_volume_adjusted} | {fees} | {float(sell_volume_adjusted)*float(last_price)} | side=sell | last={last_price} | {highest_bid=}')
 
                             # sell for real if test mode is set to false
                             if not test_mode:
-                                sell = place_order(symbol, pairing, float(sell_volume_adjusted)*float(last_price), 'sell', last_price)
+                                sell = place_order(symbol, pairing, float(sell_volume_adjusted)*float(highest_bid), 'sell', highest_bid)
                                 logger.info("Finish sell place_order")
 
 
@@ -244,6 +245,7 @@ def main():
                                 sold_coins[coin] = sell
                                 sold_coins[coin] = sell.__dict__
                                 sold_coins[coin].pop("local_vars_configuration")
+                                sold_coins[coin]['highest_bid'] = highest_bid
                                 sold_coins[coin]['profit'] = f'{float(last_price) - stored_price}'
                                 sold_coins[coin]['relative_profit_%'] = f'{(float(last_price) - stored_price) / stored_price * 100}%'
                             else:

--- a/main.py
+++ b/main.py
@@ -325,11 +325,15 @@ def main():
                     if announcement_coin in gateio_supported_currencies:
                         
                         # get latest price object
-                        price = get_last_price(announcement_coin, pairing, True)
+                        lp = get_last_price(announcement_coin, pairing, False)
 
-                        if float(price) == 0:
+                        if float(lp.price) == 0:
                             continue # wait for positive price
-
+                        
+                        buffer = 0.005
+                        price = lp.last
+                        if float(lp.lowest_ask) > 0:
+                            price = float(lp.lowest_ask) + (float(lp.lowest_ask) * buffer)
 
                         volume = config['TRADE_OPTIONS']['QUANTITY']
                         

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ import os.path
 import sys, os
 
 
-old_coins = ["JASMY", "LIT"]
+old_coins = ["MATIC", "TRVL"]
 
 # loads local configuration
 config = load_config('config.yml')

--- a/new_listings_scraper.py
+++ b/new_listings_scraper.py
@@ -142,13 +142,15 @@ def get_upcoming_gateio_listings(pairing, new_listings):
         symbol = new_listings[0]
     
     start_time_utc = get_listing_start(symbol, pairing)
-    if start_time_utc and (start_time_utc.timestamp() - datetime.now().timestamp()) <= seconds_offset: # within seconds of listing
-        found_coins = get_coins_by_accouncement_text(f"Will list ({symbol})", pairing)
-        price = get_last_price(symbol, pairing, True)
-        logger.info(f"[Gateio listing] {seconds_offset} seconds to go!! Lowest ask: {price}.  Starting ")
-    
-        if found_coins and len(found_coins) > 0:
-            return found_coins
+    if(start_time_utc):
+        diff = datetime.fromtimestamp(start_time_utc.timestamp()) - datetime.fromtimestamp(datetime.now().timestamp())
+        if diff.total_seconds() <= seconds_offset: # within seconds of listing
+            found_coins = get_coins_by_accouncement_text(f"Will list ({symbol})", pairing)
+            price = get_last_price(symbol, pairing, True)
+            logger.info(f"[Gateio listing] {seconds_offset} seconds to go!! Lowest ask: {price}.  Starting buy phase.")
+        
+            if found_coins and len(found_coins) > 0:
+                return found_coins
     
     return False
 
@@ -297,7 +299,7 @@ def search_gateio_and_update(pairing, new_listings):
         latest_coins = get_upcoming_gateio_listings(pairing, new_listings)
         if latest_coins:
             try:
-                ready = is_currency_trade_ready(latest_coins[0], pairing)
+                ready = is_currency_trade_ready(latest_coins[0], pairing) or True
                 #price = get_last_price(latest_coins[0], pairing, True)
                 if ready:
                         logger.info(f"[Gate.io] Found new coin {latest_coins[0]}!! Adding to new listings.")

--- a/new_listings_scraper.py
+++ b/new_listings_scraper.py
@@ -244,7 +244,7 @@ def search_binance_and_update(pairing):
     """
     Pretty much our main func for binance
     """
-    count = 297
+    count = 597
     while not globals.stop_threads:
         sleep_time = 3
         for x in range(sleep_time):
@@ -279,8 +279,8 @@ def search_binance_and_update(pairing):
                 store_binance_announcement(l)
             
             count = count + sleep_time
-            if count % 300 == 0:
-                logger.info("Five minutes have passed.  Checking for coin announcements on Binanace every 3 seconds (in a separate thread)")
+            if count % 600 == 0:
+                logger.info("Ten minutes have passed.  Checking for coin announcements on Binanace every 3 seconds (in a separate thread)")
                 count = 0
         except Exception as e:
             logger.info(e)
@@ -293,7 +293,7 @@ def search_gateio_and_update(pairing, new_listings):
     """
     Pretty much our main func for gateio listings
     """
-    count = 299
+    count = 599
     while not globals.stop_threads:
         
         latest_coins = get_upcoming_gateio_listings(pairing, new_listings)
@@ -320,11 +320,11 @@ def search_gateio_and_update(pairing, new_listings):
         
         
         count = count + 1
-        if count % 300 == 0:
+        if count % 600 == 0:
             nl = ""
             if len(new_listings) > 0:
                 nl = new_listings[0]
-            logger.info(f"Five minutes have passed.  Checking for coin listing {nl} on Gate.io every 1 seconds (in a separate thread)")
+            logger.info(f"Ten minutes have passed.  Checking for coin listing {nl} on Gate.io every 1 seconds (in a separate thread)")
             count = 0
        
         time.sleep(1)
@@ -336,7 +336,7 @@ def search_kucion_and_update():
     """
     Pretty much our main func for gateio listings
     """
-    count = 297
+    count = 597
     while not globals.stop_threads:
         sleep_time = 3
         for x in range(sleep_time):
@@ -359,8 +359,8 @@ def search_kucion_and_update():
                     
             
             count = count + sleep_time
-            if count % 300 == 0:
-                logger.info("Five minutes have passed.  Checking for coin announcements on Kucoin every 3 seconds (in a separate thread)")
+            if count % 600 == 0:
+                logger.info("Ten minutes have passed.  Checking for coin announcements on Kucoin every 3 seconds (in a separate thread)")
                 count = 0
         except Exception as e:
             logger.info(e)
@@ -391,7 +391,7 @@ def get_all_gateio_currencies(single=False):
         if single:
             return gateio_supported_currencies
         else:
-            for x in range(300):
+            for x in range(600):
                 time.sleep(1)
                 if globals.stop_threads:
                     break

--- a/new_listings_scraper.py
+++ b/new_listings_scraper.py
@@ -135,16 +135,20 @@ def get_coins_by_accouncement_text(latest_announcement, pairing):
 
 def get_upcoming_gateio_listings(pairing, new_listings):
     logger.debug("Pulling announcement page for [adds + trading pairs] or [will list] scenarios")
-
+    seconds_offset = 10
     if len(new_listings) == 0:
         return False
     else:
         symbol = new_listings[0]
     
-    found_coins = get_coins_by_accouncement_text(f"Will list ({symbol})", pairing)    
+    start_time_utc = get_listing_start(symbol, pairing)
+    if start_time_utc and (start_time_utc.timestamp() - datetime.now().timestamp()) <= seconds_offset: # within seconds of listing
+        found_coins = get_coins_by_accouncement_text(f"Will list ({symbol})", pairing)
+        price = get_last_price(symbol, pairing, True)
+        logger.info(f"[Gateio listing] {seconds_offset} seconds to go!! Lowest ask: {price}.  Starting ")
     
-    if found_coins and len(found_coins) > 0:
-        return found_coins
+        if found_coins and len(found_coins) > 0:
+            return found_coins
     
     return False
 

--- a/trade_client.py
+++ b/trade_client.py
@@ -1,5 +1,4 @@
 from logger import logger
-import pandas as pd
 from auth.gateio_auth import *
 import gate_api
 from gate_api import ApiClient, Configuration, Order, SpotApi

--- a/trade_client.py
+++ b/trade_client.py
@@ -33,7 +33,7 @@ def get_last_price(base,quote, return_price_only):
         assert len(tickers) == 1
         t = tickers[0]
         if return_price_only:
-            return t.last
+            return t.lowest_ask
     
         logger.info(f"GET PRICE: {t.currency_pair} | last={t.last} | change%={t.change_percentage} | lowest_ask={t.lowest_ask} | highest_bid={t.highest_bid} | base_volue={t.base_volume} | quote_volume={t.quote_volume}")
         return t


### PR DESCRIPTION
Changed the strategy for gate.io upcoming listings 
- fetch the listing time from the API response (when applying an order that will fail)
- offer buy orders at the `lowest_ask` price (not the `last` price)
- add "buffer" as a percentage rate to increase the ask amount a little more than the `lowest_ask`
- wait for "x" amount of seconds before the announcement begins and execute buy orders immediately (until successful). They will fail with a known error until the coin is tradable. The idea here is that you move the buy phase of the main thread before the coin is able to be purchased (not once it is able to be purchased). 
- changed logs of auxiliar threads to report every 10 minutes